### PR TITLE
    1) Removed psu link on About page.  2) To fix the hover text: Added ...

### DIFF
--- a/app/views/generic_files/_groups_description.html.erb
+++ b/app/views/generic_files/_groups_description.html.erb
@@ -1,0 +1,1 @@
+<p> The list of groups in the drop-down marked &quot;Select a group&quot; is a list of groups managed by <%=t('sufia.institution_name') %>'s Division of Information Technology. You may select a specific group and assign an access level for a file within <%=t('sufia.product_name') %> - similar to adding user access levels.</p>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -43,9 +43,9 @@ Permissions in GW ScholarSpace are hierarchical. This means that you cannot set 
 </p><p>
 
 <b>Share With</b>
-You may grant "View/Download" or "Edit" access for specific users and/or groups to files. Enter a valid GW Access Account Id, one at a time, select the access level for that user and click Add.
+You may grant "View/Download" or "Edit" access for specific users and/or groups to files. Enter a valid GW Account Id, one at a time, select the access level for that user and click Add.
 
-The list of groups in the drop-down marked "Select a group" is a list of User Managed Groups managed by GW's ITS department. You may select a specific group and assign an access level for a file within GW ScholarSpace - similar to adding user access levels. However, management of these groups and their membership is handled centrally at umg.its.psu.edu.
+The list of groups in the drop-down marked "Select a group" is a list of groups managed by GW's Division of Information Technology. You may select a specific group and assign an access level for a file within GW ScholarSpace - similar to adding user access levels.
 </p><p>
 
 <b>Permission Definitions</b>


### PR DESCRIPTION
...custom _groups_description.html.erb to override sufia's, which includes hard-coded reference to psu.edu URL.  Will push a fix to sufia to genericize (see #131).  Updated text to not only remove psu link but also to eliminate implication that groups are actually user-managed (vs. DIT-managed). Also updated to Division of IT (was: ITS), and removed the term "Access".  Fixes #130